### PR TITLE
fix(widget): correct engine status URL

### DIFF
--- a/engine-status/index.php
+++ b/engine-status/index.php
@@ -1,6 +1,7 @@
 <?php
-/**
- * Copyright 2005-2019 Centreon
+
+/*
+ * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -19,11 +20,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give Centreon
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -68,16 +69,18 @@ try {
     $widgetObj = new CentreonWidget($centreon, $db_centreon);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
 
-    $autoRefresh = 0;
-    $autoRefresh = $preferences['autoRefresh'];
+    $autoRefresh = filter_var($preferences['autoRefresh'], FILTER_VALIDATE_INT);
+    if ($autoRefresh === false || $autoRefresh < 5) {
+        $autoRefresh = 30;
+    }
 } catch (InvalidArgumentException $e) {
     echo $e->getMessage() . "<br/>";
     exit;
 }
 
-$path = $centreon_path . "www/widgets/engine-status/src/";
+$path = $centreon_path . 'www/widgets/engine-status/src/';
 $template = new Smarty();
-$template = initSmartyTplForPopup($path, $template, "./", $centreon_path);
+$template = initSmartyTplForPopup($path, $template, './', $centreon_path);
 
 $dataLat = array();
 $dataEx = array();
@@ -96,7 +99,7 @@ $sql = "SELECT
     WHERE T1.instance_id = :idP AND T1.host_id = T2.host_id AND T2.enabled = '1' and T2.check_type = '0'";
 
 $res = $db->prepare($sql);
-$res->bindValue(':idP', $idP, PDO::PARAM_INT);
+$res->bindValue(':idP', $idP, \PDO::PARAM_INT);
 $res->execute();
 while ($row = $res->fetch()) {
     $row['h_max'] = round($row['h_max'], 3);
@@ -115,7 +118,7 @@ $sql = "SELECT
     WHERE T1.instance_id = :idP AND T1.host_id = T2.host_id AND T2.enabled = '1' and T2.check_type = '0'";
 
 $res = $db->prepare($sql);
-$res->bindValue(':idP', $idP, PDO::PARAM_INT);
+$res->bindValue(':idP', $idP, \PDO::PARAM_INT);
 $res->execute();
 while ($row = $res->fetch()) {
     $row['h_max'] = round($row['h_max'], 3);
@@ -134,7 +137,7 @@ $sql = "SELECT
     WHERE h.instance_id = :idP";
 
 $res = $db->prepare($sql);
-$res->bindValue(':idP', $idP, PDO::PARAM_INT);
+$res->bindValue(':idP', $idP, \PDO::PARAM_INT);
 $res->execute();
 while ($row = $res->fetch()) {
     $dataSth[] = $row;
@@ -150,7 +153,7 @@ $sql = "SELECT
     WHERE h.host_id = s.host_id AND h.instance_id = :idP";
 
 $res = $db->prepare($sql);
-$res->bindValue(':idP', $idP, PDO::PARAM_INT);
+$res->bindValue(':idP', $idP, \PDO::PARAM_INT);
 $res->execute();
 while ($row = $res->fetch()) {
     $dataSts[] = $row;

--- a/engine-status/index.php
+++ b/engine-status/index.php
@@ -68,13 +68,13 @@ try {
     $widgetObj = new CentreonWidget($centreon, $db_centreon);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
 
-    if (empty($preferences['poller'] || (int) $preferences['poller'] === 0)) {
+    if (empty($preferences['poller']) || (int) $preferences['poller'] === 0) {
         throw new \InvalidArgumentException('Pollers preferences can\'t be empty');
     }
 
     $autoRefresh = 0;
     $autoRefresh = $preferences['autoRefresh'];
-} catch (Exception $e) {
+} catch (InvalidArgumentException $e) {
     echo $e->getMessage() . "<br/>";
     exit;
 }

--- a/engine-status/index.php
+++ b/engine-status/index.php
@@ -68,10 +68,6 @@ try {
     $widgetObj = new CentreonWidget($centreon, $db_centreon);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
 
-    if (empty($preferences['poller']) || (int) $preferences['poller'] === 0) {
-        throw new \InvalidArgumentException('Pollers preferences can\'t be empty');
-    }
-
     $autoRefresh = 0;
     $autoRefresh = $preferences['autoRefresh'];
 } catch (InvalidArgumentException $e) {

--- a/engine-status/src/engine-status.ihtml
+++ b/engine-status/src/engine-status.ihtml
@@ -19,9 +19,9 @@
             <h4>Status</h4>
             <tr class="ListHeader">
                 <td></td>
-                <td class="ListColHeaderLeft"><a href="/centreon/main.php?p=10201" target="_blank">Services</a></td>
+                <td class="ListColHeaderLeft"><a href="/centreon/main.php?p=50502" target="_blank">Services</a></td>
                 <td></td>
-                <td class="ListColHeaderLeft"><a href="/centreon/main.php?p=10201" target="_blank">Hosts</a></td>
+                <td class="ListColHeaderLeft"><a href="/centreon/main.php?p=50502" target="_blank">Hosts</a></td>
             </tr>
             <tr class="list_one">
                 <td class="ListColLeft">Ok</td>
@@ -60,7 +60,7 @@
             <tr>
                 <td>
                     <table class="styleTable ListTable">
-                        <a href="/centreon/main.php?p=10201" target="_blank"><h4>Check Latency</h4></a>
+                        <a href="/centreon/main.php?p=50502" target="_blank"><h4>Check Latency</h4></a>
                         <tr class="ListHeader">
                             <td class="ListColHeaderLeft">type</td>
                             <td class="ListColHeaderCenter">AVG</td>
@@ -111,7 +111,7 @@
                 </td>
                 <td>
                     <table class="styleTable ListTable">
-                        <a href="/centreon/main.php?p=10201" target="_blank"><h4>Check the execution time</h4></a>
+                        <a href="/centreon/main.php?p=50502" target="_blank"><h4>Check the execution time</h4></a>
                         <tr class="ListHeader">
                             <td class="ListColHeaderLeft">type</td>
                             <td class="ListColHeaderCenter">AVG</td>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR update the URL to access to Engine Statistics from Engine Status Widget. 

**Fixes** # MON-5405

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 1.6.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create a custom view with the engine-status widget. With this patch the link should redirect to /main.php?p=50502 instead fo /main.php?p=10201

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
