### PR TITLE
fix(secu): use jQuery 3.5.1 min file

### DIFF
--- a/engine-status/src/engine-status.ihtml
+++ b/engine-status/src/engine-status.ihtml
@@ -150,7 +150,7 @@
         var widgetId = "{$widgetId}";
         var autoRefresh = "{$autoRefresh}";
     </script>
-    <script type="text/javascript" src="../../include/common/javascript/jquery/jquery.js"></script>
+    <script type="text/javascript" src="../../include/common/javascript/jquery/jquery.min.js"></script>
     <script type="text/javascript" src="../../include/common/javascript/jquery/jquery-ui.js"></script>
     <script type="text/javascript" src="../../include/common/javascript/widgetUtils.js"></script>
     <script type="text/javascript" src="src/data_js.js"></script>


### PR DESCRIPTION
## Description

Replace the jQuery path to use Centreon's minified file

**Fixes** # (MON-6573)
Linked to https://github.com/centreon/centreon/pull/9481

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

