### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/engine-status/configs.xml
+++ b/engine-status/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>This widget displays operational metrics of a monitoring engine (latency and execution time of the checks) as well as the number of hosts and services per status.</description>
-    <version>21.10.0-beta.1</version>
+    <version>21.10.0</version>
     <keywords>centreon, widget, status, engine</keywords>
     <screenshot></screenshot>
     <thumbnail>./widgets/engine-status/resources/logo1.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix